### PR TITLE
Add global rules

### DIFF
--- a/templar/api/publish.py
+++ b/templar/api/publish.py
@@ -7,6 +7,7 @@ Users can use this module with the following import statement:
 """
 
 from templar import linker
+from templar.linker import Block
 from templar.api.config import Config
 from templar.api.rules.core import VariableRule
 from templar.exceptions import TemplarError
@@ -64,6 +65,9 @@ def publish(config, source=None, template=None, destination=None, jinja_env=None
             if rule.applies(source, destination):
                 if isinstance(rule, VariableRule):
                     variables.update(rule.apply_with_destination(str(all_block), destination))
+                elif rule.is_global():
+                    result_content = rule.apply_with_destination(str(all_block), destination=destination)
+                    all_block = Block(all_block.source_path, all_block.name, [result_content])
                 else:
                     all_block.apply_rule(rule, destination=destination)
         block_variables.update(linker.get_block_dict(all_block))

--- a/templar/api/rules/core.py
+++ b/templar/api/rules/core.py
@@ -59,6 +59,18 @@ class Rule:
         """
         return self.apply_with_destination(content, None)
 
+    @classmethod
+    def is_global(cls):
+        """
+        Returns whether this rule should be applied globally.
+
+        If you return true rather than the rule being applied per segment it is applied globally
+
+        Note that this removes the separation between segments so ideally this should only be used in a postprocessing
+            rule
+        """
+        return False
+
 
 class SubstitutionRule(Rule):
     """An abstract class that represents a rule that transforms the content that is being processed,

--- a/templar/api/rules/core.py
+++ b/templar/api/rules/core.py
@@ -67,7 +67,7 @@ class Rule:
         If you return true rather than the rule being applied per segment it is applied globally
 
         Note that this removes the separation between segments so ideally this should only be used in a postprocessing
-            rule
+            rule for code that does not interact with templates since it flattens out the blocks.
         """
         return False
 


### PR DESCRIPTION
Add rules that can apply globally. It's really the only way to give full control to the AttachCode rule that we use in the code inclusion PR